### PR TITLE
Add simple user authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,17 @@ Budgeteer is a demo budget tracking application with a FastAPI backend and a Str
    streamlit run app.py
    ```
 
+## Usage
+
+1. Register a user by sending a POST to `/register` with a JSON body containing `username` and `password`.
+2. Log in via `/login` to receive a session token.
+3. Include the token in an `Authorization: Bearer <token>` header for all subsequent requests from the Streamlit UI.
+
 ## Planned Features
 
 - Record income and expenses with categories
 - View running balance over time
 - Pie chart summary by category
 - Simple CRUD API for transactions
+- User registration and login with session tokens
 

--- a/app.py
+++ b/app.py
@@ -6,10 +6,40 @@ import pandas as pd
 import plotly.express as px
 
 FORECAST_API = "http://127.0.0.1:8000/forecast"
-
 API = "http://127.0.0.1:8000/tx"   # FastAPI base URL
+LOGIN_API = "http://127.0.0.1:8000/login"
+REGISTER_API = "http://127.0.0.1:8000/register"
 
 st.title("Budgeteer – quick demo")
+
+if "token" not in st.session_state:
+    st.session_state["token"] = None
+    st.session_state["username"] = ""
+
+st.sidebar.header("Account")
+if st.session_state["token"]:
+    st.sidebar.write(f"Logged in as {st.session_state['username']}")
+    if st.sidebar.button("Logout"):
+        st.session_state["token"] = None
+        st.session_state["username"] = ""
+        st.experimental_rerun()
+else:
+    username = st.sidebar.text_input("Username")
+    password = st.sidebar.text_input("Password", type="password")
+    if st.sidebar.button("Login"):
+        r = requests.post(LOGIN_API, json={"username": username, "password": password})
+        if r.status_code == 200:
+            st.session_state["token"] = r.json()["token"]
+            st.session_state["username"] = username
+            st.experimental_rerun()
+        else:
+            st.sidebar.error("Login failed")
+    if st.sidebar.button("Register"):
+        r = requests.post(REGISTER_API, json={"username": username, "password": password})
+        if r.status_code == 200:
+            st.sidebar.success("Registered. Please log in.")
+        else:
+            st.sidebar.error("Registration failed")
 
 # ── input form ───────────────────────────────────────────────
 st.subheader("Add a transaction")
@@ -33,16 +63,34 @@ if st.button("Save"):
     if amount == 0:
         st.warning("Amount can’t be zero")
     else:
-        requests.post(API, json={
-            "tx_date": str(tx_date),
-            "amount": amount,
-            "label": label
-        })
-        st.success("Saved!")
-        st.rerun()        # refresh the page
+        if not st.session_state["token"]:
+            st.error("Please log in first")
+        else:
+            headers = {"Authorization": f"Bearer {st.session_state['token']}"}
+            r = requests.post(API, json={
+                "tx_date": str(tx_date),
+                "amount": amount,
+                "label": label
+            }, headers=headers)
+            if r.status_code == 200:
+                st.success("Saved!")
+                st.rerun()        # refresh the page
+            else:
+                st.error("Error saving")
 
 # ── fetch + show data ────────────────────────────────────────
-data = requests.get(API).json()
+headers = None
+if st.session_state["token"]:
+    headers = {"Authorization": f"Bearer {st.session_state['token']}"}
+    resp = requests.get(API, headers=headers)
+    if resp.status_code == 200:
+        data = resp.json()
+    else:
+        data = []
+        st.error("Failed to load data")
+else:
+    st.info("Please log in to view data")
+    data = []
 df = pd.DataFrame(data)
 st.dataframe(df)
 
@@ -84,7 +132,9 @@ if not df.empty:
     st.plotly_chart(fig2, use_container_width=True)
 
     # ---- forecast chart -------------------------------------------
-    forecast_data = requests.get(FORECAST_API).json()
+    forecast_headers = {"Authorization": f"Bearer {st.session_state['token']}"}
+    forecast_resp = requests.get(FORECAST_API, headers=forecast_headers)
+    forecast_data = forecast_resp.json() if forecast_resp.status_code == 200 else []
     forecast_df = pd.DataFrame(forecast_data)
     if not forecast_df.empty:
         forecast_df["tx_date"] = pd.to_datetime(forecast_df["tx_date"])

--- a/main.py
+++ b/main.py
@@ -2,23 +2,64 @@
 
 from datetime import date, timedelta
 from typing import Optional, List
+import hashlib
+import uuid
 import pandas as pd
 from sklearn.linear_model import LinearRegression
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends, Header
 from sqlmodel import SQLModel, Field, Session, create_engine, select
 from fastapi import HTTPException
 
 app = FastAPI()
 engine = create_engine("sqlite:///budgeteer.db", echo=False)
 
+tokens: dict[str, int] = {}
+
+
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def authenticate_user(username: str, password: str) -> Optional['User']:
+    with Session(engine) as s:
+        user = s.exec(select(User).where(User.username == username)).first()
+        if user and user.password_hash == hash_password(password):
+            return user
+    return None
+
+
+def get_current_user(authorization: str = Header(...)) -> 'User':
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid authorization header")
+    token = authorization.split()[1]
+    user_id = tokens.get(token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    with Session(engine) as s:
+        user = s.get(User, user_id)
+        if not user:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        return user
+
 # ------------ Models -------------------------------------------------
+class User(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    username: str = Field(index=True, unique=True)
+    password_hash: str
+
+
 class TxIn(SQLModel):                 # <- used only for incoming JSON
     tx_date: date
     amount: float
     label: str
 
+class UserIn(SQLModel):
+    username: str
+    password: str
+
 class Tx(SQLModel, table=True):       # <- ORM table + outward schema
     id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id")
     tx_date: date
     amount: float
     label: str
@@ -29,9 +70,32 @@ def init_db() -> None:
     SQLModel.metadata.create_all(engine)
 
 # ---------- Endpoints ------------------------------------------------
+@app.post("/register")
+def register(user_in: UserIn):
+    with Session(engine) as s:
+        existing = s.exec(select(User).where(User.username == user_in.username)).first()
+        if existing:
+            raise HTTPException(status_code=400, detail="Username taken")
+        user = User(username=user_in.username, password_hash=hash_password(user_in.password))
+        s.add(user)
+        s.commit()
+        s.refresh(user)
+        return {"message": "registered"}
+
+
+@app.post("/login")
+def login(user_in: UserIn):
+    user = authenticate_user(user_in.username, user_in.password)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = uuid.uuid4().hex
+    tokens[token] = user.id
+    return {"token": token}
+
+
 @app.post("/tx", response_model=Tx)
-def add_tx(tx_in: TxIn) -> Tx:
-    tx = Tx(**tx_in.model_dump())           # cast JSON -> ORM object
+def add_tx(tx_in: TxIn, current_user: User = Depends(get_current_user)) -> Tx:
+    tx = Tx(**tx_in.model_dump(), user_id=current_user.id)           # cast JSON -> ORM object
     with Session(engine) as s:
         s.add(tx)
         s.commit()
@@ -39,25 +103,27 @@ def add_tx(tx_in: TxIn) -> Tx:
         return tx                           # <-- SINGLE object
 
 @app.get("/tx", response_model=List[Tx])
-def list_tx() -> List[Tx]:
+def list_tx(current_user: User = Depends(get_current_user)) -> List[Tx]:
     with Session(engine) as s:
-        return s.exec(select(Tx)).all()     # <-- LIST of objects
+        statement = select(Tx).where(Tx.user_id == current_user.id)
+        return s.exec(statement).all()     # <-- LIST of objects
 # ---------------------------------------------------------------------
 @app.delete("/tx/{tx_id}", status_code=204)
-def delete_tx(tx_id: int) -> None:
+def delete_tx(tx_id: int, current_user: User = Depends(get_current_user)) -> None:
     with Session(engine) as s:
         tx = s.get(Tx, tx_id)
-        if not tx:
+        if not tx or tx.user_id != current_user.id:
             raise HTTPException(status_code=404, detail="Not found")
         s.delete(tx)
         s.commit()
 
 
 @app.get("/forecast")
-def get_forecast(days: int = 7):
+def get_forecast(days: int = 7, current_user: User = Depends(get_current_user)):
     """Return predicted running balance for the next ``days`` days."""
     with Session(engine) as s:
-        txs = s.exec(select(Tx)).all()
+        statement = select(Tx).where(Tx.user_id == current_user.id)
+        txs = s.exec(statement).all()
         if not txs:
             raise HTTPException(status_code=404, detail="No transactions")
 


### PR DESCRIPTION
## Summary
- implement user model and session token auth in FastAPI app
- require auth for transaction and forecast endpoints
- add login/registration sidebar in the Streamlit UI
- update README with authentication usage instructions

## Testing
- `python -m py_compile main.py app.py`