### PR TITLE
Add recurring transaction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Use the Streamlit selector to choose a model. Predictions are color coded:
 
 These visual cues help interpret upcoming spending at a glance.
 
+## Recurring Transactions
+
+Transactions can be marked as recurring either via the `/tx` API or the
+Streamlit form. When `recurring` is enabled, three future monthly entries are
+created automatically. Upcoming recurring items are available from the
+`/reminders` endpoint and displayed in the UI.
+
 ## Planned Features
 
 - Record income and expenses with categories

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ FORECAST_API = "http://127.0.0.1:8000/forecast"
 API = "http://127.0.0.1:8000/tx"   # FastAPI base URL
 LOGIN = "http://127.0.0.1:8000/login"
 REGISTER = "http://127.0.0.1:8000/register"
+REMINDERS = "http://127.0.0.1:8000/reminders"
 
 st.title("Budgeteer – quick demo")
 
@@ -49,6 +50,7 @@ with col2:
     amount = st.number_input("Amount", value=0.0, step=0.01, format="%.2f")
 with col3:
     label = st.selectbox("Category", options=categories, index=4)  # default “Food”
+recurring = st.checkbox("Recurring monthly", value=False)
 
 headers = {"Authorization": f"Bearer {st.session_state['token']}"}
 
@@ -59,7 +61,8 @@ if st.button("Save"):
         requests.post(API, json={
             "tx_date": str(tx_date),
             "amount": amount,
-            "label": label
+            "label": label,
+            "recurring": recurring
         }, headers=headers)
         st.success("Saved!")
         st.rerun()        # refresh the page
@@ -68,6 +71,13 @@ if st.button("Save"):
 data = requests.get(API, headers=headers).json()
 df = pd.DataFrame(data)
 st.dataframe(df)
+
+# show upcoming recurring transactions
+reminders = requests.get(REMINDERS, headers=headers).json()
+reminder_df = pd.DataFrame(reminders)
+if not reminder_df.empty:
+    st.subheader("Upcoming recurring transactions")
+    st.dataframe(reminder_df)
 
 # ── running-balance chart ───────────────────────────────────
 if not df.empty:


### PR DESCRIPTION
## Summary
- support recurring transactions and create future entries
- expose reminder API endpoint
- show upcoming recurring entries in Streamlit UI
- document how to use the new feature

## Testing
- `python -m py_compile main.py app.py`