### PR TITLE
Fix forward reference in FastAPI dependency

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ JWT_SECRET = "budgeteer-secret"
 JWT_ALGORITHM = "HS256"
 
 
-def get_current_user(authorization: str = Header(None)) -> User:
+def get_current_user(authorization: str = Header(None)) -> "User":
     if not authorization:
         raise HTTPException(status_code=401, detail="Missing token")
     token = authorization.replace("Bearer", "").strip()


### PR DESCRIPTION
## Summary
- avoid NameError in `get_current_user` by quoting `User` type annotation

## Testing
- `python -m py_compile main.py app.py`
