### PR TITLE
Add setup script and dependencies

### DIFF
--- a/.codex.yaml
+++ b/.codex.yaml
@@ -1,0 +1,2 @@
+setup: ./setup.sh
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ passlib[bcrypt]
 catboost
 neuralprophet
 PyJWT
+httpx
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 -m pip install --upgrade pip
+pip install -r requirements.txt
+pip install pytest
+


### PR DESCRIPTION
## Summary
- add `setup.sh` to install project dependencies and pytest
- configure Codex to run the setup script
- include `httpx` in `requirements.txt` for tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*