### PR TITLE
Implement basic budget goals and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Use the Streamlit selector to choose a model. Predictions are color coded:
 
 These visual cues help interpret upcoming spending at a glance.
 
+## Budget Goals
+
+Each user can now set a monthly budget limit using the sidebar. A progress bar
+shows how much of the budget has been spent so far for the current month.
+
+## Transaction Search
+
+Transactions are sorted newest first and a search box lets you filter by label,
+making it easier to find past entries.
+
 ## Recurring Transactions
 
 Transactions can be marked as recurring either via the `/tx` API or the

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -53,3 +53,12 @@ def test_forecast():
     r = client.get("/forecast", params={"days": 3}, headers=headers)
     assert r.status_code == 200
     assert len(r.json()) == 3
+
+
+def test_budget_goal():
+    headers = register_and_login("g", "h")
+    r = client.post("/goal", params={"amount": 100}, headers=headers)
+    assert r.status_code == 200
+    r = client.get("/goal", headers=headers)
+    assert r.status_code == 200
+    assert r.json()["amount"] == 100


### PR DESCRIPTION
## Summary
- add side bar budget goal display with progress
- show onboarding hint and search filter
- sort transactions and split income vs expenses charts
- log transaction actions and cache forecasts
- implement /goal API with tests

## Testing
- `python -m py_compile main.py app.py`
- `python -m pytest -q` *(fails: No module named pytest)*