### PR TITLE
Fix TestClient compatibility by pinning httpx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ passlib[bcrypt]
 catboost
 neuralprophet
 PyJWT
-httpx
+httpx<0.26
 


### PR DESCRIPTION
## Summary
- pin `httpx` to a compatible version (<0.26)

## Testing
- `python -m pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*