### PR TITLE
Pin httpx to <0.25

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ passlib[bcrypt]
 catboost
 neuralprophet
 PyJWT
-httpx
+httpx<0.25
 


### PR DESCRIPTION
## Summary
- pin httpx to version <0.25 in requirements.txt

## Testing
- `python -m pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*