### PR TITLE
Implement logout and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ curl -H "Authorization: Bearer <TOKEN>" http://127.0.0.1:8000/tx
 ```
 
 The Streamlit app automatically stores the JWT once you log in and
-includes it in subsequent requests.
+includes it in subsequent requests. Use the **Logout** button in the
+sidebar to clear the token and return to the login screen.
 
 See [docs/PLANNING.md](docs/PLANNING.md) for contributor roles, milestones and additional instructions.
 

--- a/app.py
+++ b/app.py
@@ -42,6 +42,11 @@ if "token" not in st.session_state:
             st.sidebar.error(r.json().get("detail", "Login failed"))
     st.stop()
 
+st.sidebar.header("Account")
+if st.sidebar.button("Logout"):
+    del st.session_state["token"]
+    st.experimental_rerun()
+
 # first time help
 if not st.session_state.get("seen_help"):
     st.info("Use the form below to add income or expenses. Switch the type to 'Expense' for money you spend.")

--- a/main.py
+++ b/main.py
@@ -239,6 +239,7 @@ def _forecast_cached(user_id: int, days: int, model: str, last_ts: float):
             [{"tx_date": t.tx_date, "amount": t.amount} for t in txs]
         )
         df = df.groupby("tx_date")["amount"].sum().sort_index()
+        df.index = pd.to_datetime(df.index)
         running = df.cumsum()
 
         base = running.index.min()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,9 +19,9 @@ def temp_db(monkeypatch):
 client = TestClient(main.app)
 
 def register_and_login(username="user", password="pass"):
-    r = client.post("/register", data={"username": username, "password": password})
+    r = client.post("/register", params={"username": username, "password": password})
     assert r.status_code == 200
-    r = client.post("/login", data={"username": username, "password": password})
+    r = client.post("/login", params={"username": username, "password": password})
     assert r.status_code == 200
     token = r.json()["token"]
     return {"Authorization": f"Bearer {token}"}


### PR DESCRIPTION
## Summary
- add a logout option in Streamlit sidebar
- explain logout in README
- fix forecast data conversion to datetime
- update tests to use query parameters for authentication

## Testing
- `python -m pytest -q`