### PR TITLE
Support propagating edits to recurring series

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Transactions can be marked as recurring either via the `/tx` API or the
 Streamlit form. When `recurring` is enabled, three future monthly entries are
 created automatically. Upcoming recurring items are available from the
 `/reminders` endpoint and displayed in the UI.
+Editing a recurring transaction now offers an option to update all future
+instances in that series so your recurring amounts stay consistent.
 
 ## Planned Features
 

--- a/app.py
+++ b/app.py
@@ -148,6 +148,7 @@ if not df.empty:
                 etype = st.radio("Type", ["Income", "Expense"], index=0 if row['amount']>0 else 1)
                 elabel = st.selectbox("Category", categories, index=categories.index(row['label']))
                 erec = st.checkbox("Recurring monthly", value=row['recurring'])
+                prop = st.checkbox("Apply to future entries", value=False)
                 if st.button("Save", key=f"save{row['id']}"):
                     final_amt = eamount if etype == "Income" else -abs(eamount)
                     resp = requests.put(
@@ -158,6 +159,7 @@ if not df.empty:
                             "label": elabel,
                             "recurring": erec,
                         },
+                        params={"propagate": prop},
                         headers=auth_headers,
                     )
                     if resp.status_code == 200:


### PR DESCRIPTION
## Summary
- add optional `propagate` flag to update_tx API
- update recurring instances when propagating changes
- add checkbox in Streamlit UI to apply edits to future recurring entries
- document new recurring edit behaviour

## Testing
- `python -m py_compile main.py app.py`
- `pytest -q`