### PR TITLE
Add recurring extension, password change, logout and tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,6 +48,14 @@ def test_add_tx_zero_amount():
     r = client.post("/tx", json=payload, headers=headers)
     assert r.status_code == 422
 
+
+def test_add_tx_future_date():
+    headers = register_and_login("x", "y")
+    tomorrow = main.date.today() + main.timedelta(days=1)
+    payload = {"tx_date": str(tomorrow), "amount": 5.0, "label": "Food"}
+    r = client.post("/tx", json=payload, headers=headers)
+    assert r.status_code == 422
+
 def test_forecast():
     headers = register_and_login("e", "f")
     payload = {"tx_date": str(main.date.today()), "amount": 5.0, "label": "Food"}
@@ -94,3 +102,69 @@ def test_budget_goal_new_month(monkeypatch):
         user = s.exec(select(main.User).where(main.User.username == "i")).first()
         goals = s.exec(select(main.BudgetGoal).where(main.BudgetGoal.user_id == user.id)).all()
         assert len(goals) == 2
+
+
+def test_toggle_recurring():
+    headers = register_and_login("t1", "pw")
+    payload = {"tx_date": str(main.date.today()), "amount": 10.0, "label": "Food"}
+    r = client.post("/tx", json=payload, headers=headers)
+    tx_id = r.json()["id"]
+
+    # toggle to recurring
+    r = client.put(f"/tx/{tx_id}", json={**payload, "recurring": True}, headers=headers)
+    assert r.status_code == 200
+    r = client.get("/tx", headers=headers)
+    assert len(r.json()) == 4  # original + 3 future
+
+    # toggle back to non-recurring
+    r = client.put(f"/tx/{tx_id}", json=payload, headers=headers)
+    assert r.status_code == 200
+    r = client.get("/tx", headers=headers)
+    assert len(r.json()) == 1
+
+
+def test_delete_recurring_series():
+    headers = register_and_login("del", "pw")
+    payload = {"tx_date": str(main.date.today()), "amount": -5.0, "label": "Food", "recurring": True}
+    r = client.post("/tx", json=payload, headers=headers)
+    tx_id = r.json()["id"]
+    r = client.get("/tx", headers=headers)
+    assert len(r.json()) == 4
+    # delete first transaction -> removes future ones
+    r = client.delete(f"/tx/{tx_id}", headers=headers)
+    assert r.status_code == 204
+    r = client.get("/tx", headers=headers)
+    assert len(r.json()) == 0
+
+
+def test_change_password():
+    headers = register_and_login("chuser", "oldpw")
+    r = client.post(
+        "/change_password",
+        json={"current_password": "oldpw", "new_password": "newpw"},
+        headers=headers,
+    )
+    assert r.status_code == 200
+    r = client.post("/login", params={"username": "chuser", "password": "newpw"})
+    assert r.status_code == 200
+
+
+def test_recurring_extension(monkeypatch):
+    headers = register_and_login("ext", "pw")
+    today = main.date.today()
+    payload = {"tx_date": str(today), "amount": 5.0, "label": "Food", "recurring": True}
+    client.post("/tx", json=payload, headers=headers)
+    r = client.get("/tx", headers=headers)
+    assert len(r.json()) == 4
+
+    future_day = today + main.timedelta(days=65)
+
+    class FixedDate(main.date.__class__):
+        @classmethod
+        def today(cls):
+            return future_day
+
+    monkeypatch.setattr(main, "date", FixedDate)
+
+    r = client.get("/tx", headers=headers)
+    assert len(r.json()) == 6


### PR DESCRIPTION
## Summary
- extend recurring transactions beyond three months
- add password change API endpoint and Streamlit form
- handle JWT expiration gracefully on frontend and add logout/change password UI
- add programmatic creation of future recurring entries when listing or getting reminders
- extend tests for new scenarios including recurring management and password changes

## Testing
- `pytest -q`