### PR TITLE
Refactor frontend UI with MUI

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import {
+  Container,
+  Box,
+  Typography,
+  TextField,
+  Button,
+  List,
+  ListItem,
+} from '@mui/material';
 
 const API_BASE = process.env.REACT_APP_API_BASE || 'http://localhost:8000';
 
@@ -30,25 +39,29 @@ export default function App() {
 
   if(!token) {
     return (
-      <div>
-        <h3>Login</h3>
-        <input value={username} onChange={e=>setUsername(e.target.value)} placeholder="User" />
-        <input type="password" value={password} onChange={e=>setPassword(e.target.value)} placeholder="Password" />
-        <button onClick={login}>Login</button>
-      </div>
+      <Container maxWidth="sm" sx={{ mt: 4 }}>
+        <Typography variant="h4" gutterBottom>Login</Typography>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField label="User" value={username} onChange={e=>setUsername(e.target.value)} />
+          <TextField label="Password" type="password" value={password} onChange={e=>setPassword(e.target.value)} />
+          <Button variant="contained" onClick={login}>Login</Button>
+        </Box>
+      </Container>
     );
   }
 
   return (
-    <div>
-      <h3>Add Transaction</h3>
-      <input value={amount} onChange={e=>setAmount(e.target.value)} placeholder="Amount" />
-      <input value={label} onChange={e=>setLabel(e.target.value)} placeholder="Label" />
-      <button onClick={addTx}>Save</button>
-      <h3>Transactions</h3>
-      <ul>
-        {txs.map(tx => <li key={tx.id}>{tx.label}: {tx.amount}</li>)}
-      </ul>
-    </div>
+    <Container maxWidth="sm" sx={{ mt: 4 }}>
+      <Typography variant="h4" gutterBottom>Add Transaction</Typography>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <TextField label="Amount" value={amount} onChange={e=>setAmount(e.target.value)} />
+        <TextField label="Label" value={label} onChange={e=>setLabel(e.target.value)} />
+        <Button variant="contained" onClick={addTx}>Save</Button>
+      </Box>
+      <Typography variant="h5" sx={{ mt: 4 }}>Transactions</Typography>
+      <List>
+        {txs.map(tx => <ListItem key={tx.id}>{tx.label}: {tx.amount}</ListItem>)}
+      </List>
+    </Container>
   );
 }


### PR DESCRIPTION
## Summary
- switch App.js to Material UI components
- use simple Container + Box layout for login and transactions

## Testing
- `pytest -q`
