### PR TITLE
Add React build and docker static web service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 __pycache__/
 budgeteer.db
 *.py[cod]
+
+# Node
+frontend/node_modules/
+frontend/dist/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,5 +18,14 @@ services:
       - backend
     ports:
       - "8501:8501"
+  web:
+    build:
+      context: ./frontend
+    environment:
+      - REACT_APP_API_BASE=http://backend:8000
+    depends_on:
+      - backend
+    ports:
+      - "3000:80"
 volumes:
   db-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18 AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+ARG REACT_APP_API_BASE=http://backend:8000
+ENV REACT_APP_API_BASE=$REACT_APP_API_BASE
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,6 +8,17 @@ npm install
 
 # start dev server
 npm start
+
+# create production build
+npm run build
 ```
 
 The app supports login, adding a transaction and listing transactions using Material UI components.
+
+Running `npm run build` outputs static files to `dist/`. These files are served
+by the `web` service in `docker-compose.yml` using nginx. You can also serve the
+build locally with:
+
+```
+npx serve -s dist
+```


### PR DESCRIPTION
## Summary
- add node/webpack artifacts to .gitignore
- build React frontend with a new Dockerfile and serve with nginx
- expose web service in docker-compose
- document build and serving instructions in frontend README

## Testing
- `pytest -q`