### PR TITLE
fix: resolve Infinity% and NaN% display issues in budget calculations

### DIFF
--- a/frontend/src/components/TransactionModal.tsx
+++ b/frontend/src/components/TransactionModal.tsx
@@ -29,13 +29,28 @@ const TransactionModal = ({ isOpen, onClose, onSuccess, initialType = 'expense',
   const amountInputRef = useRef<HTMLInputElement>(null)
   const { token } = useAuth()
 
-  // Load last used category from localStorage
+  // Load last used category from localStorage or use initial
   useEffect(() => {
-    if (!initialCategory) {
+    if (initialCategory) {
+      setCategory(initialCategory)
+    } else {
       const lastCategory = localStorage.getItem('lastCategory_' + type) || (type === 'income' ? 'Income' : 'Food')
       setCategory(lastCategory)
     }
   }, [type, initialCategory])
+  
+  // Reset form when modal opens/closes
+  useEffect(() => {
+    if (!isOpen) {
+      // Reset form when closing
+      setAmount('')
+      setNotes('')
+      setRecurring(false)
+      setError('')
+      setShowSuccess(false)
+      setDate(new Date().toISOString().split('T')[0])
+    }
+  }, [isOpen])
 
   // Focus on amount input when modal opens
   useEffect(() => {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -87,7 +87,7 @@ const Dashboard = () => {
       if (goalResponse.data) {
         setBudgetGoal(goalResponse.data)
         budgetRemaining = Math.max(0, goalResponse.data.amount - monthSpent)
-        percentUsed = (monthSpent / goalResponse.data.amount) * 100
+        percentUsed = goalResponse.data.amount > 0 ? (monthSpent / goalResponse.data.amount) * 100 : 0
       }
 
       setStats({
@@ -166,7 +166,7 @@ const Dashboard = () => {
             </div>
             <span className={`text-sm font-medium ${stats.currentBalance >= 0 ? 'text-green-600' : 'text-red-600'}`}>
               {stats.currentBalance >= 0 ? '+' : '-'}
-              {((Math.abs(stats.currentBalance) - Math.abs(stats.monthSpent)) / Math.abs(stats.monthSpent) * 100).toFixed(0)}%
+              {stats.monthSpent > 0 ? ((Math.abs(stats.currentBalance) - Math.abs(stats.monthSpent)) / Math.abs(stats.monthSpent) * 100).toFixed(0) : '0'}%
             </span>
           </div>
           <h3 className="text-sm font-medium text-gray-600">Current Balance</h3>


### PR DESCRIPTION
- Fix division by zero in Dashboard percentUsed calculation
- Fix percentage calculation when monthSpent is 0
- Improve TransactionModal to properly use pre-selected categories from QuickAddButtons
- Reset form fields when modal closes
- QuickAddButtons now correctly pre-select Food, Transport, Shopping, or Income categories