### PR TITLE
fix: pin passlib and bcrypt versions to resolve Railway deployment issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ plotly
 pandas
 requests
 scikit-learn
-passlib[bcrypt]
+passlib==1.7.4
+bcrypt==4.0.1
 python-multipart
 catboost
 neuralprophet


### PR DESCRIPTION
- Pin passlib to 1.7.4 and bcrypt to 4.0.1 to fix AttributeError
- Resolves issue where bcrypt.__about__ module was removed in newer versions