### PR TITLE
fix: add PyJWT to minimal requirements for Railway deployment

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -2,7 +2,7 @@ fastapi==0.104.1
 uvicorn[standard]==0.24.0
 sqlmodel==0.0.14
 pydantic==2.5.0
-python-jose[cryptography]==3.3.0
+PyJWT==2.8.0
 passlib==1.7.4
 bcrypt==4.0.1
 python-multipart==0.0.6


### PR DESCRIPTION
- Replace python-jose with PyJWT as auth.py uses 'import jwt'
- This fixes the ModuleNotFoundError during Railway deployment