### PR TITLE
fix: add missing series_id to RecurringExpense interface

### DIFF
--- a/frontend/src/pages/RecurringExpenses.tsx
+++ b/frontend/src/pages/RecurringExpenses.tsx
@@ -28,6 +28,7 @@ interface RecurringExpense {
   is_active: boolean;
   reminder_days?: number;
   notes?: string;
+  series_id: number;
   color?: string;
   icon?: string;
 }


### PR DESCRIPTION
- Fixes TypeScript build error TS2339
- Backend returns series_id, frontend interface now matches