### PR TITLE
fix: remove /auth prefix to match frontend expectations

### DIFF
--- a/main_minimal.py
+++ b/main_minimal.py
@@ -54,7 +54,7 @@ app.add_middleware(
 )
 
 # Include routers
-app.include_router(auth_router, prefix="/auth", tags=["auth"])
+app.include_router(auth_router, tags=["auth"])
 app.include_router(transactions_router, tags=["transactions"])
 app.include_router(forecast_router, tags=["forecast"])
 app.include_router(recurring_router, prefix="/recurring", tags=["recurring"])


### PR DESCRIPTION
- Login endpoint is now at /login instead of /auth/login
- Fixes 'Method Not Allowed' error on login